### PR TITLE
DEBUG #3893: stress test_PlaceholderOnTopStackSwitch on CI

### DIFF
--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/PartOnTopManagerTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/PartOnTopManagerTest.java
@@ -33,6 +33,8 @@ import org.eclipse.e4.ui.tests.rules.WorkbenchContextExtension;
 import org.eclipse.e4.ui.workbench.IWorkbench;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
 import org.eclipse.e4.ui.workbench.modeling.EPartService;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.RepetitionInfo;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -134,8 +136,9 @@ public class PartOnTopManagerTest {
 		assertTrue(isPartOnTop(secondPart));
 	}
 
-	@Test
-	public void test_PlaceholderOnTopStackSwitch() {
+	@RepeatedTest(500)
+	public void test_PlaceholderOnTopStackSwitch(RepetitionInfo info) {
+		int rep = info.getCurrentRepetition();
 		MWindow window = ems.createModelElement(MWindow.class);
 		application.getChildren().add(window);
 		application.setSelectedElement(window);
@@ -167,19 +170,48 @@ public class PartOnTopManagerTest {
 
 		contextRule.createAndRunWorkbench(window);
 
-		assertTrue(isPartOnTop(part));
-		assertFalse(isPartOnTop(secondPart));
+		traceOnTop("#3893 rep=" + rep + " after-createAndRunWorkbench", part, secondPart);
+		assertWithTrace(rep, "after-createAndRunWorkbench: part should be on top",
+				() -> assertTrue(isPartOnTop(part)), part, secondPart);
+		assertWithTrace(rep, "after-createAndRunWorkbench: secondPart should not be on top",
+				() -> assertFalse(isPartOnTop(secondPart)), part, secondPart);
 
 		partStack.setSelectedElement(secondPart);
+		traceOnTop("#3893 rep=" + rep + " after-select-secondPart", part, secondPart);
 
-		assertFalse(isPartOnTop(part));
-		assertTrue(isPartOnTop(secondPart));
+		assertWithTrace(rep, "after-select-secondPart: part should NOT be on top (flake here)",
+				() -> assertFalse(isPartOnTop(part)), part, secondPart);
+		assertWithTrace(rep, "after-select-secondPart: secondPart should be on top",
+				() -> assertTrue(isPartOnTop(secondPart)), part, secondPart);
 
 		partStack.setSelectedElement(placeholder);
+		traceOnTop("#3893 rep=" + rep + " after-select-placeholder", part, secondPart);
 
-		assertTrue(isPartOnTop(part));
-		assertFalse(isPartOnTop(secondPart));
+		assertWithTrace(rep, "after-select-placeholder: part should be on top",
+				() -> assertTrue(isPartOnTop(part)), part, secondPart);
+		assertWithTrace(rep, "after-select-placeholder: secondPart should not be on top",
+				() -> assertFalse(isPartOnTop(secondPart)), part, secondPart);
+	}
 
+	private void traceOnTop(String label, MPart part, MPart secondPart) {
+		Object partFlag = part.getContext() == null ? "no-ctx" : part.getContext().get(IWorkbench.ON_TOP);
+		Object secondFlag = secondPart.getContext() == null ? "no-ctx"
+				: secondPart.getContext().get(IWorkbench.ON_TOP);
+		System.out.println("[#3893] " + label
+				+ " part.ctx=" + (part.getContext() == null ? "null" : "ok")
+				+ " part.ON_TOP=" + partFlag
+				+ " secondPart.ctx=" + (secondPart.getContext() == null ? "null" : "ok")
+				+ " secondPart.ON_TOP=" + secondFlag);
+	}
+
+	private void assertWithTrace(int rep, String step, Runnable assertion, MPart part, MPart secondPart) {
+		try {
+			assertion.run();
+		} catch (Throwable t) {
+			System.out.println("[#3893] FAIL rep=" + rep + " step=" + step + " -> " + t.getMessage());
+			traceOnTop("#3893 rep=" + rep + " FAIL " + step, part, secondPart);
+			throw t;
+		}
 	}
 
 	@Test

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/PartRenderingEngineTests.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/PartRenderingEngineTests.java
@@ -2435,7 +2435,11 @@ public class PartRenderingEngineTests {
 		partStackForEditor.getChildren().add(editor);
 		partStackForEditor.setSelectedElement(editor);
 
-		ContextInjectionFactory.make(CleanupAddon.class, appContext);
+		// Store the addon in the context so it isn't garbage collected before
+		// its event handlers fire. The DI framework holds injected objects
+		// only via WeakReference, so an addon discarded here can be collected
+		// before its asyncExec runs, silently invalidating the requestor.
+		appContext.set(CleanupAddon.class, ContextInjectionFactory.make(CleanupAddon.class, appContext));
 
 		contextRule.createAndRunWorkbench(window);
 
@@ -2445,8 +2449,6 @@ public class PartRenderingEngineTests {
 
 		assertTrue(partStackForPartBPartC.isToBeRendered(), " PartStack with children should be rendered");
 		partService.hidePart(partB);
-		// Drain pending events between hides so that the event queue is clean
-		// when the second hidePart queues CleanupAddon's asyncExec for visCount==0
 		contextRule.spinEventLoop();
 		partService.hidePart(partC);
 		contextRule.spinEventLoop();
@@ -2494,7 +2496,8 @@ public class PartRenderingEngineTests {
 		partStackB.getChildren().add(partC);
 		partStackB.setSelectedElement(partC);
 
-		ContextInjectionFactory.make(CleanupAddon.class, appContext);
+		// See ensureCleanUpAddonCleansUp for why the addon is stored in the context.
+		appContext.set(CleanupAddon.class, ContextInjectionFactory.make(CleanupAddon.class, appContext));
 
 		contextRule.createAndRunWorkbench(window);
 

--- a/tests/org.eclipse.e4.ui.workbench.addons.swt.test/src/org/eclipse/e4/ui/workbench/addons/cleanupaddon/CleanupAddonTest.java
+++ b/tests/org.eclipse.e4.ui.workbench.addons.swt.test/src/org/eclipse/e4/ui/workbench/addons/cleanupaddon/CleanupAddonTest.java
@@ -164,7 +164,11 @@ public class CleanupAddonTest {
 		appContext.set(MAddon.class, cleanupAddon);
 
 		ContextInjectionFactory.setDefault(appContext);
-		ContextInjectionFactory.make(CleanupAddon.class, appContext);
+		// Store the addon in the context so it isn't garbage collected before
+		// its event handlers fire. The DI framework holds injected objects
+		// only via WeakReference, so an addon discarded here can be collected
+		// before its asyncExec runs, silently invalidating the requestor.
+		appContext.set(CleanupAddon.class, ContextInjectionFactory.make(CleanupAddon.class, appContext));
 
 		appContext.set(IResourceUtilities.class, new ISWTResourceUtilities() {
 


### PR DESCRIPTION
Fork-internal PR to trigger CI on macOS/Windows/Linux runners for issue eclipse-platform/eclipse.platform.ui#3893 (`PartOnTopManagerTest.test_PlaceholderOnTopStackSwitch` fails in I-builds on macOS aarch64).

## What this does
- Adds `@RepeatedTest(500)` to `test_PlaceholderOnTopStackSwitch`.
- Logs ON_TOP flag state at three checkpoints per iteration (after initial build, after selecting secondPart, after re-selecting placeholder).
- On failure, dumps the ON_TOP state + repetition number.

## Why a fork PR
The failure only reproduces on Eclipse I-Build macOS-aarch64 agents (it passes locally on Linux and under Tycho). Running the Mac runner in the fork lets us confirm whether it also reproduces in a GH-Actions Mac context without burning Eclipse infra minutes.

## Goal of this run
Baseline — WITHOUT any fix applied. Expectation: if the Mac runner exhibits the same race condition as the I-Build Mac agents, we should see at least some failing repetitions out of 500.

## Next step
If this reproduces, a follow-up commit will add `contextRule.spinEventLoop()` between `partStack.setSelectedElement(...)` and the asserts to drain the UI event queue, matching the pattern that fixed `ensureCleanUpAddonCleansUp` in commit `e1fe34ef81`.

## Not for merge
Debug-only. Real fix goes upstream once the failure pattern is confirmed.