### PR TITLE
DEBUG: investigate flaky testPreviousChoicesAvailableForExtension

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/ChooseWorkspaceWithSettingsDialog.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/ChooseWorkspaceWithSettingsDialog.java
@@ -34,6 +34,7 @@ import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.jface.fieldassist.ControlDecoration;
 import org.eclipse.jface.fieldassist.FieldDecorationRegistry;
 import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.jface.util.Util;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.ScrolledComposite;
@@ -152,6 +153,20 @@ public class ChooseWorkspaceWithSettingsDialog extends ChooseWorkspaceDialog {
 		sectionClient.setVisible(expanded);
 		clientData.exclude = !expanded;
 		toggle.setText(expanded ? "\u25BE" : "\u25B8"); //$NON-NLS-1$ //$NON-NLS-2$
+
+		// On macOS Cocoa, setBackground/setForeground on a hidden widget is dropped
+		// once the widget is realized. Re-apply colors to the check buttons when
+		// the section first becomes visible.
+		if (Util.isMac()) {
+			sectionClient.addListener(SWT.Show, e -> {
+				for (Control child : sectionClient.getChildren()) {
+					if (child instanceof Button button && (button.getStyle() & SWT.CHECK) != 0) {
+						button.setBackground(workArea.getBackground());
+						button.setForeground(workArea.getForeground());
+					}
+				}
+			});
+		}
 
 		Listener toggleListener = e -> {
 			boolean newState = !sectionClient.getVisible();

--- a/bundles/org.eclipse.ui.workbench/.settings/.api_filters
+++ b/bundles/org.eclipse.ui.workbench/.settings/.api_filters
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <component id="org.eclipse.ui.workbench" version="2">
+    <resource path="eclipseui/org/eclipse/ui/dialogs/FilteredItemsSelectionDialog.java" type="org.eclipse.ui.dialogs.FilteredItemsSelectionDialog">
+        <filter id="336658481">
+            <message_arguments>
+                <message_argument value="org.eclipse.ui.dialogs.FilteredItemsSelectionDialog"/>
+                <message_argument value="JOB_FAMILY"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="eclipseui/org/eclipse/ui/dialogs/YesNoCancelListSelectionDialog.java" type="org.eclipse.ui.dialogs.YesNoCancelListSelectionDialog">
         <filter id="576778288">
             <message_arguments>

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/dialogs/FilteredItemsSelectionDialog.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/dialogs/FilteredItemsSelectionDialog.java
@@ -50,6 +50,7 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.ProgressMonitorWrapper;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
+import org.eclipse.core.runtime.jobs.ISchedulingRule;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.ActionContributionItem;
@@ -237,6 +238,17 @@ public abstract class FilteredItemsSelectionDialog extends SelectionStatusDialog
 	private boolean isShownForTheFirstTime = true;
 
 	/**
+	 * Job family under which all background filtering and refresh jobs of this
+	 * dialog are grouped. Tests may use this with
+	 * {@link org.eclipse.core.runtime.jobs.IJobManager#join(Object, org.eclipse.core.runtime.IProgressMonitor)}
+	 * to deterministically wait for the filter/refresh pipeline to settle.
+	 *
+	 * @noreference This field is not intended to be referenced by clients.
+	 * @since 3.138
+	 */
+	public static final Object JOB_FAMILY = new Object();
+
+	/**
 	 * Creates a new instance of the class.
 	 *
 	 * @param shell shell to parent the dialog on
@@ -250,8 +262,34 @@ public abstract class FilteredItemsSelectionDialog extends SelectionStatusDialog
 		filterJob = new FilterJob();
 		contentProvider = new ContentProvider();
 		refreshCacheJob = new RefreshCacheJob();
+		// All three jobs mutate / read the same ContentProvider state (items,
+		// duplicates, lastFilteredItems, ...). Without a common scheduling rule
+		// they can run concurrently on different worker threads, racing
+		// FilterHistoryJob.contentProvider.reset() against FilterJob's
+		// fillContentProvider() and silently emptying or corrupting the visible
+		// items. The rule is per-dialog, so separate dialogs still run in
+		// parallel.
+		ISchedulingRule pipelineRule = new ContentProviderSerialRule();
+		filterHistoryJob.setRule(pipelineRule);
+		filterJob.setRule(pipelineRule);
+		refreshCacheJob.setRule(pipelineRule);
 		itemsListSeparator = new ItemsListSeparator(WorkbenchMessages.FilteredItemsSelectionDialog_separatorLabel);
 		selectionMode = NONE;
+	}
+
+	/**
+	 * Per-dialog mutex rule used to serialize the filter/refresh pipeline jobs.
+	 */
+	private static final class ContentProviderSerialRule implements ISchedulingRule {
+		@Override
+		public boolean contains(ISchedulingRule rule) {
+			return rule == this;
+		}
+
+		@Override
+		public boolean isConflicting(ISchedulingRule rule) {
+			return rule == this;
+		}
 	}
 
 	/**
@@ -1315,6 +1353,11 @@ public abstract class FilteredItemsSelectionDialog extends SelectionStatusDialog
 			return new Status(IStatus.OK, PlatformUI.PLUGIN_ID, IStatus.OK, EMPTY_STRING, null);
 		}
 
+		@Override
+		public boolean belongsTo(Object family) {
+			return family == JOB_FAMILY;
+		}
+
 	}
 
 	/**
@@ -1418,6 +1461,11 @@ public abstract class FilteredItemsSelectionDialog extends SelectionStatusDialog
 		protected void canceling() {
 			super.canceling();
 			contentProvider.stopReloadingCache();
+		}
+
+		@Override
+		public boolean belongsTo(Object family) {
+			return family == JOB_FAMILY;
 		}
 
 	}
@@ -1854,6 +1902,11 @@ public abstract class FilteredItemsSelectionDialog extends SelectionStatusDialog
 			return Status.OK_STATUS;
 		}
 
+		@Override
+		public boolean belongsTo(Object family) {
+			return family == JOB_FAMILY;
+		}
+
 	}
 
 	/**
@@ -1975,6 +2028,11 @@ public abstract class FilteredItemsSelectionDialog extends SelectionStatusDialog
 				}
 			}
 
+		}
+
+		@Override
+		public boolean belongsTo(Object family) {
+			return family == JOB_FAMILY;
 		}
 
 	}

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/quickaccess/QuickAccessContents.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/quickaccess/QuickAccessContents.java
@@ -128,6 +128,17 @@ public abstract class QuickAccessContents {
 		this.providers = providers;
 	}
 
+	// DEBUG: instrumentation for testPreviousChoicesAvailableForExtension flakiness.
+	// Remove before merging the fix.
+	public Job debugGetComputeProposalsJob() {
+		return computeProposalsJob;
+	}
+
+	// DEBUG: instrumentation. Remove before merging the fix.
+	public QuickAccessProvider[] debugGetProviders() {
+		return providers;
+	}
+
 	/**
 	 * Returns the number of items the table can fit in its current layout
 	 */

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/quickaccess/QuickAccessMatcher.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/quickaccess/QuickAccessMatcher.java
@@ -16,7 +16,6 @@ package org.eclipse.ui.internal.quickaccess;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
 import org.eclipse.ui.quickaccess.QuickAccessElement;
 
 /**
@@ -34,29 +33,15 @@ public final class QuickAccessMatcher {
 	}
 
 	private static final int[][] EMPTY_INDICES = new int[0][0];
-	private static final String WS_WILD_START = "^\\s*(\\*|\\?)*"; //$NON-NLS-1$
-	private static final String WS_WILD_END = "(\\*|\\?)*\\s*$"; //$NON-NLS-1$
-	private static final String ANY_WS = "\\s+"; //$NON-NLS-1$
-	private static final String EMPTY_STR = ""; //$NON-NLS-1$
-	private static final String PAR_START = "\\("; //$NON-NLS-1$
-	private static final String PAR_END = "\\)"; //$NON-NLS-1$
-	private static final String ONE_CHAR = ".?"; //$NON-NLS-1$
 
 	// whitespaces filter and patterns
 	private String wsFilter;
 	private Pattern wsPattern;
 
-	/**
-	 * Get the existing {@link Pattern} for the given filter, or create a new one.
-	 * The generated pattern will replace whitespace with * to match all.
-	 */
 	private Pattern getWhitespacesPattern(String filter) {
 		if (wsPattern == null || !filter.equals(wsFilter)) {
 			wsFilter = filter;
-			String sFilter = filter.replaceFirst(WS_WILD_START, EMPTY_STR).replaceFirst(WS_WILD_END, EMPTY_STR)
-					.replaceAll(PAR_START, ONE_CHAR).replaceAll(PAR_END, ONE_CHAR);
-			sFilter = String.format(".*(%s).*", sFilter.replaceAll(ANY_WS, ").*(")); //$NON-NLS-1$//$NON-NLS-2$
-			wsPattern = safeCompile(sFilter);
+			wsPattern = QuickAccessMatching.whitespacesPattern(filter);
 		}
 		return wsPattern;
 	}
@@ -65,61 +50,13 @@ public final class QuickAccessMatcher {
 	private String wcFilter;
 	private Pattern wcPattern;
 
-	/**
-	 * Get the existing {@link Pattern} for the given filter, or create a new one.
-	 * The generated pattern will handle '*' and '?' wildcards.
-	 */
 	private Pattern getWildcardsPattern(String filter) {
-		// squash consecutive **** into a single *
-		filter = filter.replaceAll("\\*+", "*"); //$NON-NLS-1$ //$NON-NLS-2$
-		if (wcPattern == null || !filter.equals(wcFilter)) {
-			wcFilter = filter;
-			String sFilter = filter.replaceFirst(WS_WILD_START, EMPTY_STR).replaceFirst(WS_WILD_END, EMPTY_STR)
-					.replaceAll(PAR_START, ONE_CHAR).replaceAll(PAR_END, ONE_CHAR);
-			// replace '*' and '?' with their matchers ").*(" and ").?("
-			StringBuilder sb = new StringBuilder();
-			for (int i = 0; i < sFilter.length(); i++) {
-				char c = sFilter.charAt(i);
-				if (c == '*') {
-					sb.append(").").append(c).append("("); //$NON-NLS-1$ //$NON-NLS-2$
-				} else if (c == '?') {
-					int n = 1;
-					for (; (i + 1) < sFilter.length(); i++) {
-						if (sFilter.charAt(i + 1) != '?') {
-							break;
-						}
-						n++;
-					}
-					sb.append(").").append(n == 1 ? '?' : String.format("{0,%d}", n)).append("("); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-				} else {
-					sb.append(c);
-				}
-			}
-			sFilter = String.format(".*(%s).*", sb.toString()); //$NON-NLS-1$
-			// remove empty capturing groups
-			sFilter = sFilter.replace("()", EMPTY_STR); //$NON-NLS-1$
-			//
-			wcPattern = safeCompile(sFilter);
+		String squashed = filter.replaceAll("\\*+", "*"); //$NON-NLS-1$ //$NON-NLS-2$
+		if (wcPattern == null || !squashed.equals(wcFilter)) {
+			wcFilter = squashed;
+			wcPattern = QuickAccessMatching.wildcardsPattern(squashed);
 		}
 		return wcPattern;
-	}
-
-	/**
-	 * A safe way to compile some unknown pattern, avoids possible
-	 * {@link PatternSyntaxException}. If the pattern can't be compiled, some not
-	 * matching pattern will be returned.
-	 *
-	 * @param pattern some pattern to compile, not null
-	 * @return a {@link Pattern} object compiled from given input or a dummy pattern
-	 *         which do not match anything
-	 */
-	private static Pattern safeCompile(String pattern) {
-		try {
-			return Pattern.compile(pattern, Pattern.CASE_INSENSITIVE);
-		} catch (Exception e) {
-			// A "bell" special character: should not match anything we can get
-			return Pattern.compile("\\a"); //$NON-NLS-1$
-		}
 	}
 
 	/**
@@ -134,19 +71,15 @@ public final class QuickAccessMatcher {
 	 */
 	public QuickAccessEntry match(String filter, QuickAccessProvider providerForMatching) {
 		String matchLabel = element.getMatchLabel();
-		// first occurrence of filter
-		int index = matchLabel.toLowerCase().indexOf(filter);
-		if (index != -1) {
-			index = element.getLabel().toLowerCase().indexOf(filter);
-			if (index != -1) { // match actual label
-				int quality = matchLabel.toLowerCase().equals(filter) ? QuickAccessEntry.MATCH_PERFECT
-						: (matchLabel.toLowerCase().startsWith(filter) ? QuickAccessEntry.MATCH_EXCELLENT
-								: QuickAccessEntry.MATCH_GOOD);
-				return new QuickAccessEntry(element, providerForMatching,
-						new int[][] { { index, index + filter.length() - 1 } }, EMPTY_INDICES, quality);
+		String label = element.getLabel();
+		int quality = QuickAccessMatching.substringMatchQuality(matchLabel, label, filter);
+		if (quality != -1) {
+			if (quality == QuickAccessEntry.MATCH_PARTIAL) {
+				return new QuickAccessEntry(element, providerForMatching, EMPTY_INDICES, EMPTY_INDICES, quality);
 			}
-			return new QuickAccessEntry(element, providerForMatching, EMPTY_INDICES, EMPTY_INDICES,
-					QuickAccessEntry.MATCH_PARTIAL);
+			int index = label.toLowerCase().indexOf(filter);
+			return new QuickAccessEntry(element, providerForMatching,
+					new int[][] { { index, index + filter.length() - 1 } }, EMPTY_INDICES, quality);
 		}
 		//
 		Pattern p;
@@ -161,9 +94,8 @@ public final class QuickAccessMatcher {
 		// if matches, return an entry
 		if (m.matches()) {
 			// and highlight match on the label only
-			String label = element.getLabel();
 			if (!matchLabel.equals(label)) {
-				m = p.matcher(element.getLabel());
+				m = p.matcher(label);
 				if (!m.matches()) {
 					return new QuickAccessEntry(element, providerForMatching, EMPTY_INDICES, EMPTY_INDICES,
 							QuickAccessEntry.MATCH_GOOD);
@@ -176,14 +108,13 @@ public final class QuickAccessMatcher {
 				// capturing group
 				indices[i] = new int[] { m.start(nGrp), m.end(nGrp) - 1 };
 			}
-			// return match and list of indices
-			int quality = QuickAccessEntry.MATCH_EXCELLENT;
-			return new QuickAccessEntry(element, providerForMatching, indices, EMPTY_INDICES, quality);
+			return new QuickAccessEntry(element, providerForMatching, indices, EMPTY_INDICES,
+					QuickAccessEntry.MATCH_EXCELLENT);
 		}
 		//
-		String combinedMatchLabel = (providerForMatching.getName() + " " + element.getMatchLabel()); //$NON-NLS-1$
-		String combinedLabel = (providerForMatching.getName() + " " + element.getLabel()); //$NON-NLS-1$
-		index = combinedMatchLabel.toLowerCase().indexOf(filter);
+		String combinedMatchLabel = providerForMatching.getName() + " " + matchLabel; //$NON-NLS-1$
+		String combinedLabel = providerForMatching.getName() + " " + label; //$NON-NLS-1$
+		int index = combinedMatchLabel.toLowerCase().indexOf(filter);
 		if (index != -1) { // match
 			index = combinedLabel.toLowerCase().indexOf(filter);
 			if (index != -1) { // compute highlight on label
@@ -200,7 +131,7 @@ public final class QuickAccessMatcher {
 					QuickAccessEntry.MATCH_PARTIAL);
 		}
 		//
-		String camelCase = CamelUtil.getCamelCase(element.getLabel()); // use actual label for camelcase
+		String camelCase = CamelUtil.getCamelCase(label); // use actual label for camelcase
 		index = camelCase.indexOf(filter);
 		if (index != -1) {
 			int[][] indices = CamelUtil.getCamelCaseIndices(matchLabel, index, filter.length());

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/quickaccess/QuickAccessMatching.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/quickaccess/QuickAccessMatching.java
@@ -1,0 +1,117 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Vogella GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.ui.internal.quickaccess;
+
+import java.util.regex.Pattern;
+
+/**
+ * Pure, side-effect-free helpers used by {@link QuickAccessMatcher}. Extracted
+ * so the matching/ranking rules can be unit-tested without a workbench harness.
+ *
+ * @noreference This class is not intended to be referenced by clients.
+ */
+public final class QuickAccessMatching {
+
+	private static final String WS_WILD_START = "^\\s*(\\*|\\?)*"; //$NON-NLS-1$
+	private static final String WS_WILD_END = "(\\*|\\?)*\\s*$"; //$NON-NLS-1$
+	private static final String ANY_WS = "\\s+"; //$NON-NLS-1$
+	private static final String EMPTY_STR = ""; //$NON-NLS-1$
+	private static final String PAR_START = "\\("; //$NON-NLS-1$
+	private static final String PAR_END = "\\)"; //$NON-NLS-1$
+	private static final String ONE_CHAR = ".?"; //$NON-NLS-1$
+
+	private QuickAccessMatching() {
+	}
+
+	/**
+	 * Build a regex {@link Pattern} that treats every run of whitespace in the
+	 * filter as a wildcard boundary. "text white" becomes {@code .*(text).*(white).*}.
+	 */
+	public static Pattern whitespacesPattern(String filter) {
+		String sFilter = filter.replaceFirst(WS_WILD_START, EMPTY_STR).replaceFirst(WS_WILD_END, EMPTY_STR)
+				.replaceAll(PAR_START, ONE_CHAR).replaceAll(PAR_END, ONE_CHAR);
+		sFilter = String.format(".*(%s).*", sFilter.replaceAll(ANY_WS, ").*(")); //$NON-NLS-1$ //$NON-NLS-2$
+		return safeCompile(sFilter);
+	}
+
+	/**
+	 * Build a regex {@link Pattern} that honours {@code *} and {@code ?} wildcards
+	 * in the filter. Consecutive {@code *} are squashed; runs of {@code ?} become a
+	 * bounded length match.
+	 */
+	public static Pattern wildcardsPattern(String filter) {
+		filter = filter.replaceAll("\\*+", "*"); //$NON-NLS-1$ //$NON-NLS-2$
+		String sFilter = filter.replaceFirst(WS_WILD_START, EMPTY_STR).replaceFirst(WS_WILD_END, EMPTY_STR)
+				.replaceAll(PAR_START, ONE_CHAR).replaceAll(PAR_END, ONE_CHAR);
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < sFilter.length(); i++) {
+			char c = sFilter.charAt(i);
+			if (c == '*') {
+				sb.append(").").append(c).append("("); //$NON-NLS-1$ //$NON-NLS-2$
+			} else if (c == '?') {
+				int n = 1;
+				for (; (i + 1) < sFilter.length(); i++) {
+					if (sFilter.charAt(i + 1) != '?') {
+						break;
+					}
+					n++;
+				}
+				sb.append(").").append(n == 1 ? '?' : String.format("{0,%d}", n)).append("("); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			} else {
+				sb.append(c);
+			}
+		}
+		sFilter = String.format(".*(%s).*", sb.toString()); //$NON-NLS-1$
+		sFilter = sFilter.replace("()", EMPTY_STR); //$NON-NLS-1$
+		return safeCompile(sFilter);
+	}
+
+	/**
+	 * Compile a regex or fall back to a pattern that will not match anything
+	 * normal. Never throws.
+	 */
+	public static Pattern safeCompile(String regex) {
+		try {
+			return Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
+		} catch (Exception e) {
+			return Pattern.compile("\\a"); //$NON-NLS-1$
+		}
+	}
+
+	/**
+	 * Quality for the substring-match branch of {@link QuickAccessMatcher#match}.
+	 * {@code filter} must already be lower-cased by the caller (the matcher does
+	 * this once per call).
+	 *
+	 * @return one of {@link QuickAccessEntry#MATCH_PERFECT},
+	 *         {@link QuickAccessEntry#MATCH_EXCELLENT},
+	 *         {@link QuickAccessEntry#MATCH_GOOD},
+	 *         {@link QuickAccessEntry#MATCH_PARTIAL}, or {@code -1} if the filter
+	 *         is not a substring of {@code matchLabel}.
+	 */
+	public static int substringMatchQuality(String matchLabel, String label, String filter) {
+		String lowerMatch = matchLabel.toLowerCase();
+		if (lowerMatch.indexOf(filter) == -1) {
+			return -1;
+		}
+		if (label.toLowerCase().indexOf(filter) == -1) {
+			return QuickAccessEntry.MATCH_PARTIAL;
+		}
+		if (lowerMatch.equals(filter)) {
+			return QuickAccessEntry.MATCH_PERFECT;
+		}
+		if (lowerMatch.startsWith(filter)) {
+			return QuickAccessEntry.MATCH_EXCELLENT;
+		}
+		return QuickAccessEntry.MATCH_GOOD;
+	}
+}

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/UIAllTests.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/UIAllTests.java
@@ -56,6 +56,7 @@ import org.eclipse.e4.ui.workbench.renderers.swt.StackRendererTest;
 import org.eclipse.e4.ui.workbench.renderers.swt.TabStateHandlerTest;
 import org.eclipse.e4.ui.workbench.renderers.swt.ThemeDefinitionChangedHandlerTest;
 import org.eclipse.e4.ui.workbench.renderers.swt.ToolBarManagerRendererTest;
+import org.eclipse.e4.ui.workbench.renderers.swt.ToolControlRendererTest;
 
 import org.junit.platform.suite.api.SelectClasses;
 import org.junit.platform.suite.api.Suite;
@@ -95,6 +96,7 @@ import org.junit.platform.suite.api.Suite;
 		TabStateHandlerTest.class,
 		ThemeDefinitionChangedHandlerTest.class,
 		ToolBarManagerRendererTest.class,
+		ToolControlRendererTest.class,
 		TopoSortTests.class,
 		ExtensionsSortTests.class,
 		HandlerActivationTest.class,

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/PartRenderingEngineTests.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/PartRenderingEngineTests.java
@@ -2435,7 +2435,11 @@ public class PartRenderingEngineTests {
 		partStackForEditor.getChildren().add(editor);
 		partStackForEditor.setSelectedElement(editor);
 
-		ContextInjectionFactory.make(CleanupAddon.class, appContext);
+		// Store the addon in the context so it isn't garbage collected before
+		// its event handlers fire. The DI framework holds injected objects
+		// only via WeakReference, so an addon discarded here can be collected
+		// before its asyncExec runs, silently invalidating the requestor.
+		appContext.set(CleanupAddon.class, ContextInjectionFactory.make(CleanupAddon.class, appContext));
 
 		contextRule.createAndRunWorkbench(window);
 
@@ -2445,8 +2449,6 @@ public class PartRenderingEngineTests {
 
 		assertTrue(partStackForPartBPartC.isToBeRendered(), " PartStack with children should be rendered");
 		partService.hidePart(partB);
-		// Drain pending events between hides so that the event queue is clean
-		// when the second hidePart queues CleanupAddon's asyncExec for visCount==0
 		contextRule.spinEventLoop();
 		partService.hidePart(partC);
 		contextRule.spinEventLoop();
@@ -2494,7 +2496,8 @@ public class PartRenderingEngineTests {
 		partStackB.getChildren().add(partC);
 		partStackB.setSelectedElement(partC);
 
-		ContextInjectionFactory.make(CleanupAddon.class, appContext);
+		// See ensureCleanUpAddonCleansUp for why the addon is stored in the context.
+		appContext.set(CleanupAddon.class, ContextInjectionFactory.make(CleanupAddon.class, appContext));
 
 		contextRule.createAndRunWorkbench(window);
 

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/workbench/renderers/swt/ToolControlRendererTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/workbench/renderers/swt/ToolControlRendererTest.java
@@ -1,0 +1,163 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lars Vogel and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Lars Vogel - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.e4.ui.workbench.renderers.swt;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.inject.Inject;
+
+import org.eclipse.e4.ui.model.application.MApplication;
+import org.eclipse.e4.ui.model.application.ui.basic.MTrimBar;
+import org.eclipse.e4.ui.model.application.ui.basic.MTrimmedWindow;
+import org.eclipse.e4.ui.model.application.ui.menu.MToolControl;
+import org.eclipse.e4.ui.tests.rules.WorkbenchContextExtension;
+import org.eclipse.e4.ui.workbench.IPresentationEngine;
+import org.eclipse.e4.ui.workbench.modeling.EModelService;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Label;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class ToolControlRendererTest {
+
+	private static final String BUNDLE_URI = "bundleclass://org.eclipse.e4.ui.tests/"
+			+ ToolControlRendererTest.class.getName() + "$";
+
+	@RegisterExtension
+	public WorkbenchContextExtension contextRule = new WorkbenchContextExtension();
+
+	@Inject
+	private EModelService ems;
+
+	@Inject
+	private MApplication application;
+
+	private MTrimmedWindow window;
+	private MTrimBar trimBar;
+
+	@BeforeEach
+	void setUp() {
+		window = ems.createModelElement(MTrimmedWindow.class);
+		application.getChildren().add(window);
+
+		trimBar = ems.createModelElement(MTrimBar.class);
+		window.getTrimBars().add(trimBar);
+	}
+
+	@Test
+	void testWidgetCreated() {
+		MToolControl toolControl = createToolControl("SimpleControl");
+		trimBar.getChildren().add(toolControl);
+
+		contextRule.createAndRunWorkbench(window);
+
+		assertNotNull(toolControl.getWidget(), "Widget must be created for a MToolControl");
+	}
+
+	@Test
+	void testNoChildren_widgetIsNull() {
+		MToolControl toolControl = createToolControl("EmptyControl");
+		trimBar.getChildren().add(toolControl);
+
+		contextRule.createAndRunWorkbench(window);
+
+		assertNull(toolControl.getWidget(),
+				"Widget must be null when the contribution creates no SWT children");
+	}
+
+	@Test
+	void testHiddenExplicitly_hidesControl() {
+		MToolControl toolControl = createToolControl("SimpleControl");
+		trimBar.getChildren().add(toolControl);
+
+		contextRule.createAndRunWorkbench(window);
+
+		assertTrue(toolControl.isVisible(), "Control should be visible initially");
+
+		toolControl.getTags().add(IPresentationEngine.HIDDEN_EXPLICITLY);
+		contextRule.spinEventLoop();
+
+		assertFalse(toolControl.isVisible(), "Control should be hidden after HIDDEN_EXPLICITLY tag is added");
+	}
+
+	@Test
+	void testHiddenExplicitly_removeTag_restoresVisibility() {
+		MToolControl toolControl = createToolControl("SimpleControl");
+		trimBar.getChildren().add(toolControl);
+
+		contextRule.createAndRunWorkbench(window);
+
+		toolControl.getTags().add(IPresentationEngine.HIDDEN_EXPLICITLY);
+		contextRule.spinEventLoop();
+		assertFalse(toolControl.isVisible());
+
+		toolControl.getTags().remove(IPresentationEngine.HIDDEN_EXPLICITLY);
+		contextRule.spinEventLoop();
+
+		assertTrue(toolControl.isVisible(), "Visibility must be restored after HIDDEN_EXPLICITLY tag is removed");
+	}
+
+	@Test
+	void testHideableControls_haveIndependentMenus() {
+		MToolControl tc1 = createToolControl("SimpleControl");
+		tc1.getTags().add("HIDEABLE");
+		trimBar.getChildren().add(tc1);
+
+		MToolControl tc2 = createToolControl("SimpleControl");
+		tc2.getTags().add("HIDEABLE");
+		trimBar.getChildren().add(tc2);
+
+		contextRule.createAndRunWorkbench(window);
+
+		Control widget1 = (Control) tc1.getWidget();
+		Control widget2 = (Control) tc2.getWidget();
+
+		assertNotNull(widget1.getMenu(), "First HIDEABLE control must have a context menu");
+		assertNotNull(widget2.getMenu(), "Second HIDEABLE control must have a context menu");
+		assertNotSame(widget1.getMenu(), widget2.getMenu(),
+				"Each HIDEABLE control must have its own independent menu instance");
+		assertFalse(widget1.getMenu().isDisposed(),
+				"First control's menu must not be disposed after second control is rendered");
+	}
+
+	private MToolControl createToolControl(String innerClassName) {
+		MToolControl tc = ems.createModelElement(MToolControl.class);
+		tc.setContributionURI(BUNDLE_URI + innerClassName);
+		return tc;
+	}
+
+	// --- Contribution classes used by the tests ---
+
+	public static class SimpleControl {
+		@PostConstruct
+		public void create(Composite parent) {
+			new Label(parent, SWT.NONE).setText("test");
+		}
+	}
+
+	public static class EmptyControl {
+		@PostConstruct
+		public void create(@SuppressWarnings("unused") Composite parent) {
+			// intentionally creates no SWT children
+		}
+	}
+}

--- a/tests/org.eclipse.e4.ui.workbench.addons.swt.test/src/org/eclipse/e4/ui/workbench/addons/cleanupaddon/CleanupAddonTest.java
+++ b/tests/org.eclipse.e4.ui.workbench.addons.swt.test/src/org/eclipse/e4/ui/workbench/addons/cleanupaddon/CleanupAddonTest.java
@@ -164,7 +164,11 @@ public class CleanupAddonTest {
 		appContext.set(MAddon.class, cleanupAddon);
 
 		ContextInjectionFactory.setDefault(appContext);
-		ContextInjectionFactory.make(CleanupAddon.class, appContext);
+		// Store the addon in the context so it isn't garbage collected before
+		// its event handlers fire. The DI framework holds injected objects
+		// only via WeakReference, so an addon discarded here can be collected
+		// before its asyncExec runs, silently invalidating the requestor.
+		appContext.set(CleanupAddon.class, ContextInjectionFactory.make(CleanupAddon.class, appContext));
 
 		appContext.set(IResourceUtilities.class, new ISWTResourceUtilities() {
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/ResourceInitialSelectionTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/ResourceInitialSelectionTest.java
@@ -38,6 +38,7 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableItem;
 import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.dialogs.FilteredItemsSelectionDialog;
 import org.eclipse.ui.dialogs.FilteredResourcesSelectionDialog;
 import org.eclipse.ui.internal.decorators.DecoratorManager;
 import org.eclipse.ui.tests.harness.util.DisplayHelper;
@@ -125,8 +126,11 @@ public class ResourceInitialSelectionTest {
 		dialog.open();
 		dialog.refresh();
 
-		// Don't wait for full refresh - this test checks that invalid initial
-		// selections don't cause a selection before dialog is fully loaded
+		// Intentionally no waitForDialogRefresh: this asserts that during
+		// initial load, the dialog does not pre-select anything for an
+		// invalid initial element. After the refresh pipeline drains the
+		// dialog falls back to selecting row 0, which is a separate
+		// behavior not under test here.
 
 		List<Object> selected = getSelectedItems(dialog);
 
@@ -167,8 +171,10 @@ public class ResourceInitialSelectionTest {
 		dialog.open();
 		dialog.refresh();
 
-		// Don't wait for full refresh - this test checks that filtered initial
-		// selections don't cause a selection before dialog is fully loaded
+		// Intentionally no waitForDialogRefresh: foofoo is filtered out by
+		// the *.txt pattern, so during initial load nothing is selected.
+		// After the refresh pipeline drains the dialog falls back to row 0,
+		// which is a separate behavior not under test here.
 
 		List<Object> selected = getSelectedItems(dialog);
 
@@ -274,8 +280,11 @@ public class ResourceInitialSelectionTest {
 		dialog.open();
 		dialog.refresh();
 
-		// Don't wait for full refresh - this test checks that invalid initial
-		// selections don't cause a selection before dialog is fully loaded
+		// Intentionally no waitForDialogRefresh: this asserts that during
+		// initial load, the dialog does not pre-select anything for invalid
+		// initial elements. After the refresh pipeline drains the dialog
+		// falls back to selecting row 0, which is a separate behavior not
+		// under test here.
 
 		List<Object> selected = getSelectedItems(dialog);
 
@@ -448,37 +457,21 @@ public class ResourceInitialSelectionTest {
 	}
 
 	/**
-	 * Wait for dialog refresh jobs to complete and process UI events.
-	 * This ensures background jobs finish before assertions are made.
+	 * Wait for the dialog's background filter/refresh jobs to complete.
+	 * <p>
+	 * The dialog schedules a chain of jobs on open/refresh:
+	 * {@code FilterHistoryJob → FilterJob → RefreshCacheJob → RefreshJob}. All
+	 * four are tagged with {@link FilteredItemsSelectionDialog#JOB_FAMILY}, so
+	 * we wait for that family to drain. The 30 s ceiling is a deadlock guard;
+	 * the pipeline usually completes within a few hundred milliseconds.
 	 */
 	private void waitForDialogRefresh() {
 		Display display = PlatformUI.getWorkbench().getDisplay();
-
-		// The dialog performs async operations (FilterHistoryJob → FilterJob →
-		// RefreshCacheJob → RefreshJob) to filter and populate the table after refresh()
-		// We need to wait for the table item count to stabilize before checking
-		// selection state. The count can temporarily be non-zero after the history
-		// refresh, then change again when FilterJob populates actual results.
-		// Selection is applied only in the final refresh, so we must wait for
-		// stability rather than just for any non-zero count.
-		int[] lastCount = { -1 };
-		DisplayHelper.waitForCondition(display, 5000, () -> {
+		DisplayHelper.waitForCondition(display, 30_000L, () -> {
 			processUIEvents();
-			try {
-				Table table = (Table) ((Composite) ((Composite) ((Composite) dialog.getShell().getChildren()[0])
-						.getChildren()[0]).getChildren()[0]).getChildren()[3];
-				int count = table.getItemCount();
-				if (count > 0 && count == lastCount[0]) {
-					return true; // stable non-zero count: all refreshes have completed
-				}
-				lastCount[0] = count;
-				return false;
-			} catch (Exception e) {
-				return false;
-			}
+			return Job.getJobManager().find(FilteredItemsSelectionDialog.JOB_FAMILY).length == 0;
 		});
-
-		// Final event loop processing to pick up any trailing async tasks
+		// Final event loop processing to pick up any trailing asyncExecs.
 		processUIEvents();
 	}
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessDialogTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessDialogTest.java
@@ -17,9 +17,9 @@ package org.eclipse.ui.tests.quickaccess;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEventsUntil;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.Arrays;
@@ -47,17 +47,18 @@ import org.eclipse.ui.handlers.IHandlerService;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.internal.quickaccess.QuickAccessDialog;
 import org.eclipse.ui.internal.quickaccess.QuickAccessMessages;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.DisplayHelper;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Tests the quick access UI
  * @since 3.4
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class QuickAccessDialogTest {
 
 	private class TestQuickAccessDialog extends QuickAccessDialog {
@@ -72,9 +73,6 @@ public class QuickAccessDialogTest {
 		}
 	}
 
-	@Rule
-	public CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
-
 	private static final int TIMEOUT = 5000;
 	// As defined in QuickAccessDialog and in SearchField
 	private static final int MAXIMUM_NUMBER_OF_ELEMENTS = 60;
@@ -84,7 +82,7 @@ public class QuickAccessDialogTest {
 	private IWorkbenchWindow activeWorkbenchWindow;
 
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		Arrays.stream(Display.getDefault().getShells()).filter(isQuickAccessShell).forEach(Shell::close);
 		dialogSettings = new DialogSettings("QuickAccessDialogTest" + System.currentTimeMillis());
@@ -99,7 +97,7 @@ public class QuickAccessDialogTest {
 				.map(QuickAccessDialog.class::cast);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		Arrays.stream(Display.getDefault().getShells()).filter(isQuickAccessShell)
 				.forEach(Shell::close);
@@ -130,23 +128,24 @@ public class QuickAccessDialogTest {
 		dialog.open();
 		Text text = dialog.getQuickAccessContents().getFilterText();
 		Table table = dialog.getQuickAccessContents().getTable();
-		assertTrue("Quick access filter should be empty", text.getText().isEmpty());
-		assertEquals("Quick access table should be empty", 0, table.getItemCount());
+		assertTrue(text.getText().isEmpty(), "Quick access filter should be empty");
+		assertEquals(0, table.getItemCount(), "Quick access table should be empty");
 
 		text.setText("T");
 		processEventsUntil(() -> table.getItemCount() > 1, TIMEOUT);
 		int oldCount = table.getItemCount();
-		assertTrue("Not enough quick access items for simple filter", oldCount > 3);
-		assertTrue("Too many quick access items for size of table", oldCount < MAXIMUM_NUMBER_OF_ELEMENTS);
+		assertTrue(oldCount > 3, "Not enough quick access items for simple filter");
+		assertTrue(oldCount < MAXIMUM_NUMBER_OF_ELEMENTS, "Too many quick access items for size of table");
 		final String oldFirstItemText = table.getItem(0).getText(1);
 
 		text.setText("B"); // The letter mustn't be part of the previous 1st proposal
-		assertTrue("The quick access items should have changed", DisplayHelper.waitForCondition(table.getDisplay(),
+		assertTrue(DisplayHelper.waitForCondition(table.getDisplay(),
 				TIMEOUT,
-				() -> table.getItemCount() > 1 && !table.getItem(0).getText(1).equals(oldFirstItemText)));
+				() -> table.getItemCount() > 1 && !table.getItem(0).getText(1).equals(oldFirstItemText)),
+				"The quick access items should have changed");
 		int newCount = table.getItemCount();
-		assertTrue("Not enough quick access items for simple filter", newCount > 3);
-		assertTrue("Too many quick access items for size of table", newCount < MAXIMUM_NUMBER_OF_ELEMENTS);
+		assertTrue(newCount > 3, "Not enough quick access items for simple filter");
+		assertTrue(newCount < MAXIMUM_NUMBER_OF_ELEMENTS, "Too many quick access items for size of table");
 	}
 
 	@Test
@@ -155,12 +154,13 @@ public class QuickAccessDialogTest {
 		dialog.open();
 		final Table table = dialog.getQuickAccessContents().getTable();
 		Text text = dialog.getQuickAccessContents().getFilterText();
-		assertTrue("Quick access filter should be empty", text.getText().isEmpty());
-		assertEquals("Quick access table should be empty", 0, table.getItemCount());
+		assertTrue(text.getText().isEmpty(), "Quick access filter should be empty");
+		assertEquals(0, table.getItemCount(), "Quick access table should be empty");
 
 		text.setText(TestQuickAccessComputer.TEST_QUICK_ACCESS_PROPOSAL_LABEL);
-		assertTrue("Missing contributed element", DisplayHelper.waitForCondition(dialog.getShell().getDisplay(), TIMEOUT, () ->
-				dialogContains(dialog, TestQuickAccessComputer.TEST_QUICK_ACCESS_PROPOSAL_LABEL))
+		assertTrue(DisplayHelper.waitForCondition(dialog.getShell().getDisplay(), TIMEOUT, () ->
+				dialogContains(dialog, TestQuickAccessComputer.TEST_QUICK_ACCESS_PROPOSAL_LABEL)),
+				"Missing contributed element"
 		);
 	}
 
@@ -172,11 +172,11 @@ public class QuickAccessDialogTest {
 		Text text = dialog.getQuickAccessContents().getFilterText();
 		long duration = System.currentTimeMillis();
 		text.setText(TestLongRunningQuickAccessComputer.THE_ELEMENT.getId());
-		assertTrue("UI Frozen on text change",
-				System.currentTimeMillis() - duration < TestLongRunningQuickAccessComputer.DELAY);
-		assertTrue("Missing contributed element", DisplayHelper.waitForCondition(dialog.getShell().getDisplay(), TestLongRunningQuickAccessComputer.DELAY + TIMEOUT, () ->
+		assertTrue(System.currentTimeMillis() - duration < TestLongRunningQuickAccessComputer.DELAY,
+				"UI Frozen on text change");
+		assertTrue(DisplayHelper.waitForCondition(dialog.getShell().getDisplay(), TestLongRunningQuickAccessComputer.DELAY + TIMEOUT, () ->
 			dialogContains(dialog, TestLongRunningQuickAccessComputer.THE_ELEMENT.getLabel())
-		));
+		), "Missing contributed element");
 		table.select(0);
 		activateCurrentElement(dialog);
 		duration = System.currentTimeMillis();
@@ -185,7 +185,7 @@ public class QuickAccessDialogTest {
 		assertTrue(System.currentTimeMillis() - duration < TestLongRunningQuickAccessComputer.DELAY);
 		AtomicLong tick = new AtomicLong(System.currentTimeMillis());
 		AtomicLong maxBlockedUIThread = new AtomicLong();
-		assertTrue("Missing contributed element as previous pick", DisplayHelper.waitForCondition(
+		assertTrue(DisplayHelper.waitForCondition(
 				secondDialog.getShell().getDisplay(), TestLongRunningQuickAccessComputer.DELAY + TIMEOUT, () -> {
 							long currentTick = System.currentTimeMillis();
 							long previousTick = tick.getAndSet(currentTick);
@@ -193,7 +193,7 @@ public class QuickAccessDialogTest {
 							maxBlockedUIThread.set(Math.max(maxBlockedUIThread.get(), currentDelayInUIThread));
 							return dialogContains(secondDialog,
 									TestLongRunningQuickAccessComputer.THE_ELEMENT.getLabel());
-						}));
+						}), "Missing contributed element as previous pick");
 		assertTrue(maxBlockedUIThread.get() < TestLongRunningQuickAccessComputer.DELAY);
 	}
 
@@ -208,15 +208,15 @@ public class QuickAccessDialogTest {
 		dialog.open();
 		Text text = dialog.getQuickAccessContents().getFilterText();
 		final Table table = dialog.getQuickAccessContents().getTable();
-		assertTrue("Quick access filter should be empty", text.getText().isEmpty());
-		assertEquals("Quick access table should be empty", 0, table.getItemCount());
+		assertTrue(text.getText().isEmpty(), "Quick access filter should be empty");
+		assertEquals(0, table.getItemCount(), "Quick access table should be empty");
 
 		// Set a filter to get some items
 		text.setText("T");
 		processEventsUntil(() -> table.getItemCount() > 1, TIMEOUT);
 		final int defaultCount = table.getItemCount();
-		assertTrue("Not enough quick access items for simple filter", defaultCount > 3);
-		assertTrue("Too many quick access items for size of table", defaultCount < MAXIMUM_NUMBER_OF_ELEMENTS);
+		assertTrue(defaultCount > 3, "Not enough quick access items for simple filter");
+		assertTrue(defaultCount < MAXIMUM_NUMBER_OF_ELEMENTS, "Too many quick access items for size of table");
 		final String oldFirstItemText = table.getItem(0).getText(1);
 
 		IHandlerService handlerService = PlatformUI.getWorkbench().getActiveWorkbenchWindow()
@@ -225,21 +225,21 @@ public class QuickAccessDialogTest {
 		handlerService.executeCommand("org.eclipse.ui.window.quickAccess", null); //$NON-NLS-1$
 		processEventsUntil(() -> table.getItemCount() != defaultCount, TIMEOUT);
 		final int allCount = table.getItemCount();
-		assertTrue("Turning on show all should display more items", allCount > defaultCount);
-		assertEquals("Turning on show all should not change the top item", oldFirstItemText, table.getItem(0).getText(1));
+		assertTrue(allCount > defaultCount, "Turning on show all should display more items");
+		assertEquals(oldFirstItemText, table.getItem(0).getText(1), "Turning on show all should not change the top item");
 
 		// Run the handler to turn off show all
 		handlerService.executeCommand("org.eclipse.ui.window.quickAccess", null); //$NON-NLS-1$
 		processEventsUntil(() -> table.getItemCount() != allCount, TIMEOUT);
 		// Note: The table count may one off from the old count because of shell resizing (scroll bars being added then removed)
-		assertTrue("Turning off show all should limit items shown", table.getItemCount() < allCount);
-		assertEquals("Turning off show all should not change the top item", oldFirstItemText, table.getItem(0).getText(1));
+		assertTrue(table.getItemCount() < allCount, "Turning off show all should limit items shown");
+		assertEquals(oldFirstItemText, table.getItem(0).getText(1), "Turning off show all should not change the top item");
 
 		// Run the handler to turn on show all
 		handlerService.executeCommand("org.eclipse.ui.window.quickAccess", null); //$NON-NLS-1$
 		processEventsUntil(() -> table.getItemCount() == allCount, TIMEOUT);
-		assertEquals("Turning on show all twice shouldn't change the items", allCount, table.getItemCount());
-		assertEquals("Turning on show all twice shouldn't change the top item", oldFirstItemText, table.getItem(0).getText(1));
+		assertEquals(allCount, table.getItemCount(), "Turning on show all twice shouldn't change the items");
+		assertEquals(oldFirstItemText, table.getItem(0).getText(1), "Turning on show all twice shouldn't change the top item");
 
 		// Close and reopen the shell
 		dialog.close();
@@ -250,8 +250,8 @@ public class QuickAccessDialogTest {
 		text.setText("T");
 		processEventsUntil(() -> newTable.getItemCount() > 1, TIMEOUT);
 		// Note: The table count may one off from the old count because of shell resizing (scroll bars being added then removed)
-		assertTrue("Show all should be turned off when the shell is closed and reopened",
-				newTable.getItemCount() < allCount);
+		assertTrue(newTable.getItemCount() < allCount,
+				"Show all should be turned off when the shell is closed and reopened");
 	}
 
 	@Test
@@ -263,9 +263,9 @@ public class QuickAccessDialogTest {
 		Table firstTable = dialog.getQuickAccessContents().getTable();
 		String quickAccessElementText = "Project Explorer";
 		text.setText(quickAccessElementText);
-		assertTrue("Missing entry", DisplayHelper.waitForCondition(firstTable.getDisplay(),
+		assertTrue(DisplayHelper.waitForCondition(firstTable.getDisplay(),
 				TIMEOUT,
-				() -> dialogContains(dialog, quickAccessElementText)));
+				() -> dialogContains(dialog, quickAccessElementText)), "Missing entry");
 		firstTable.select(0);
 		activateCurrentElement(dialog);
 		assertNotEquals(0, dialogSettings.getArray("orderedElements").length);
@@ -278,9 +278,9 @@ public class QuickAccessDialogTest {
 		// then try in a new SearchField
 		QuickAccessDialog secondDialog = new TestQuickAccessDialog(activeWorkbenchWindow, null);
 		secondDialog.open();
-		assertTrue("Missing entry in previous pick",
-				DisplayHelper.waitForCondition(secondDialog.getShell().getDisplay(), TIMEOUT,
-						() -> dialogContains(secondDialog, quickAccessElementText)));
+		assertTrue(DisplayHelper.waitForCondition(secondDialog.getShell().getDisplay(), TIMEOUT,
+						() -> dialogContains(secondDialog, quickAccessElementText)),
+				"Missing entry in previous pick");
 	}
 
 	private void activateCurrentElement(QuickAccessDialog dialog) {
@@ -306,10 +306,10 @@ public class QuickAccessDialogTest {
 		// then try in a new SearchField
 		QuickAccessDialog secondDialog = new TestQuickAccessDialog(activeWorkbenchWindow, null);
 		secondDialog.open();
-		assertTrue("Contributed item not found in previous choices",
-				DisplayHelper.waitForCondition(secondDialog.getShell().getDisplay(), TIMEOUT,
+		assertTrue(DisplayHelper.waitForCondition(secondDialog.getShell().getDisplay(), TIMEOUT,
 						() -> getAllEntries(secondDialog.getQuickAccessContents().getTable()).stream()
-								.anyMatch(TestQuickAccessComputer::isContributedItem)));
+								.anyMatch(TestQuickAccessComputer::isContributedItem)),
+				"Contributed item not found in previous choices");
 	}
 
 	@Test
@@ -330,11 +330,10 @@ public class QuickAccessDialogTest {
 		dialog = new TestQuickAccessDialog(activeWorkbenchWindow, null);
 		dialog.open();
 		final Table secondTable = dialog.getQuickAccessContents().getTable();
-		assertTrue("Contributed item not found in previous choices",
-				DisplayHelper.waitForCondition(secondTable.getDisplay(), TIMEOUT, //
+		assertTrue(DisplayHelper.waitForCondition(secondTable.getDisplay(), TIMEOUT, //
 						() -> getAllEntries(secondTable).stream()
-								.anyMatch(TestIncrementalQuickAccessComputer::isContributedItem)
-				));
+								.anyMatch(TestIncrementalQuickAccessComputer::isContributedItem)),
+				"Contributed item not found in previous choices");
 	}
 
 	@Test
@@ -344,9 +343,9 @@ public class QuickAccessDialogTest {
 		Text text = dialog.getQuickAccessContents().getFilterText();
 		Table table = dialog.getQuickAccessContents().getTable();
 		text.setText("P");
-		assertTrue("Not enough quick access items for simple filter",
-				DisplayHelper.waitForCondition(table.getDisplay(), TIMEOUT, () -> table.getItemCount() > 3));
-		assertTrue("Non-prefix match first", table.getItem(0).getText(1).toLowerCase().startsWith("p"));
+		assertTrue(DisplayHelper.waitForCondition(table.getDisplay(), TIMEOUT, () -> table.getItemCount() > 3),
+				"Not enough quick access items for simple filter");
+		assertTrue(table.getItem(0).getText(1).toLowerCase().startsWith("p"), "Non-prefix match first");
 	}
 
 	@Test
@@ -365,9 +364,9 @@ public class QuickAccessDialogTest {
 		Text text = dialog.getQuickAccessContents().getFilterText();
 		Table table = dialog.getQuickAccessContents().getTable();
 		text.setText("Toggle Split");
-		assertTrue("Not enough quick access items for simple filter",
-				DisplayHelper.waitForCondition(table.getDisplay(), TIMEOUT, () -> table.getItemCount() > 1));
-		assertTrue("Non-prefix match first", table.getItem(0).getText(1).toLowerCase().startsWith("toggle split"));
+		assertTrue(DisplayHelper.waitForCondition(table.getDisplay(), TIMEOUT, () -> table.getItemCount() > 1),
+				"Not enough quick access items for simple filter");
+		assertTrue(table.getItem(0).getText(1).toLowerCase().startsWith("toggle split"), "Non-prefix match first");
 	}
 
 	private List<String> getAllEntries(Table table) {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessDialogTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessDialogTest.java
@@ -26,12 +26,14 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
 
 import org.eclipse.core.commands.Command;
+import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jface.dialogs.DialogSettings;
 import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.swt.SWT;
@@ -47,10 +49,13 @@ import org.eclipse.ui.handlers.IHandlerService;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.internal.quickaccess.QuickAccessDialog;
 import org.eclipse.ui.internal.quickaccess.QuickAccessMessages;
+import org.eclipse.ui.internal.quickaccess.QuickAccessProvider;
 import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.DisplayHelper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.RepetitionInfo;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -291,25 +296,161 @@ public class QuickAccessDialogTest {
 		processEventsUntil(() -> enterPressed.widget.isDisposed(), 500);
 	}
 
-	@Test
-	public void testPreviousChoicesAvailableForExtension() {
+	// DEBUG: instrumented @RepeatedTest to chase flakiness on CI.
+	// Revert to a normal @Test before merging the final fix.
+	@RepeatedTest(500)
+	public void testPreviousChoicesAvailableForExtension(RepetitionInfo info) {
+		int iter = info.getCurrentRepetition();
+		long testStart = System.currentTimeMillis();
+		debugLog(iter, "BEGIN test iteration");
+
 		// add one selection to history
 		QuickAccessDialog dialog = new TestQuickAccessDialog(activeWorkbenchWindow, null);
+		long openStart = System.currentTimeMillis();
 		dialog.open();
+		debugLog(iter, "first dialog.open took " + (System.currentTimeMillis() - openStart) + " ms");
+		debugLogProviders(iter, dialog);
+
 		Text text = dialog.getQuickAccessContents().getFilterText();
-		text.setText(TestQuickAccessComputer.TEST_QUICK_ACCESS_PROPOSAL_LABEL);
 		final Table firstTable = dialog.getQuickAccessContents().getTable();
-		assertTrue(DisplayHelper.waitForCondition(text.getDisplay(), TIMEOUT,
-				() -> dialogContains(dialog, TestQuickAccessComputer.TEST_QUICK_ACCESS_PROPOSAL_LABEL)));
+		long setTextStart = System.currentTimeMillis();
+		text.setText(TestQuickAccessComputer.TEST_QUICK_ACCESS_PROPOSAL_LABEL);
+		debugLog(iter, "setText returned after " + (System.currentTimeMillis() - setTextStart)
+				+ " ms, text.getText()=\"" + text.getText() + "\" itemCount=" + firstTable.getItemCount());
+
+		boolean firstOk = debugWaitForDialogContains(iter, "first", dialog, firstTable,
+				TestQuickAccessComputer.TEST_QUICK_ACCESS_PROPOSAL_LABEL);
+		if (!firstOk) {
+			debugDumpFailureState(iter, "first", dialog, firstTable);
+		}
+		assertTrue(firstOk,
+				"iter=" + iter + ": contributed item not in first dialog after " + TIMEOUT + " ms");
+
 		firstTable.select(0);
 		activateCurrentElement(dialog);
+
 		// then try in a new SearchField
 		QuickAccessDialog secondDialog = new TestQuickAccessDialog(activeWorkbenchWindow, null);
+		long open2Start = System.currentTimeMillis();
 		secondDialog.open();
-		assertTrue(DisplayHelper.waitForCondition(secondDialog.getShell().getDisplay(), TIMEOUT,
-						() -> getAllEntries(secondDialog.getQuickAccessContents().getTable()).stream()
-								.anyMatch(TestQuickAccessComputer::isContributedItem)),
-				"Contributed item not found in previous choices");
+		debugLog(iter, "second dialog.open took " + (System.currentTimeMillis() - open2Start) + " ms");
+		Table secondTable = secondDialog.getQuickAccessContents().getTable();
+
+		boolean secondOk = debugWaitForCondition(iter, "second", secondDialog, secondTable,
+				() -> getAllEntries(secondTable).stream().anyMatch(TestQuickAccessComputer::isContributedItem),
+				"previous-pick contributed item");
+		if (!secondOk) {
+			debugDumpFailureState(iter, "second", secondDialog, secondTable);
+		}
+		assertTrue(secondOk,
+				"iter=" + iter + ": contributed item not found in previous choices after " + TIMEOUT + " ms");
+
+		debugLog(iter, "END test iteration, total=" + (System.currentTimeMillis() - testStart) + " ms");
+	}
+
+	// DEBUG helpers below; remove together with the @RepeatedTest above.
+	private static void debugLog(int iter, String msg) {
+		System.err.println("[QADialogTest iter=" + iter + " t=" + System.currentTimeMillis() + "] " + msg);
+	}
+
+	private static void debugLogProviders(int iter, QuickAccessDialog dialog) {
+		QuickAccessProvider[] providers = dialog.getQuickAccessContents().debugGetProviders();
+		StringBuilder sb = new StringBuilder("providers(").append(providers.length).append("): ");
+		for (QuickAccessProvider p : providers) {
+			sb.append(p.getId()).append(",");
+		}
+		debugLog(iter, sb.toString());
+	}
+
+	private static String debugJobState(QuickAccessDialog dialog) {
+		Job j = dialog.getQuickAccessContents().debugGetComputeProposalsJob();
+		if (j == null) {
+			return "computeProposalsJob=null";
+		}
+		return "computeProposalsJob state=" + j.getState() + " result=" + j.getResult();
+	}
+
+	private boolean debugWaitForDialogContains(int iter, String tag, QuickAccessDialog dialog,
+			Table table, String needle) {
+		return debugWaitForCondition(iter, tag, dialog, table,
+				() -> dialogContains(dialog, needle), "label=\"" + needle + "\"");
+	}
+
+	private boolean debugWaitForCondition(int iter, String tag, QuickAccessDialog dialog, Table table,
+			java.util.function.BooleanSupplier cond, String what) {
+		long start = System.currentTimeMillis();
+		long deadline = start + TIMEOUT;
+		int pollCount = 0;
+		while (System.currentTimeMillis() < deadline) {
+			while (Display.getCurrent().readAndDispatch()) {
+				// pump
+			}
+			pollCount++;
+			boolean ok;
+			try {
+				ok = cond.getAsBoolean();
+			} catch (RuntimeException e) {
+				debugLog(iter, tag + " poll#" + pollCount + " threw " + e);
+				throw e;
+			}
+			if (pollCount == 1 || pollCount % 10 == 0 || ok) {
+				int cnt = (table != null && !table.isDisposed()) ? table.getItemCount() : -1;
+				debugLog(iter, tag + " poll#" + pollCount + " elapsed="
+						+ (System.currentTimeMillis() - start) + " ms cond=" + ok
+						+ " itemCount=" + cnt + " " + debugJobState(dialog));
+			}
+			if (ok) {
+				debugLog(iter, tag + " satisfied(" + what + ") after "
+						+ (System.currentTimeMillis() - start) + " ms, polls=" + pollCount);
+				return true;
+			}
+			try {
+				Thread.sleep(10);
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				return false;
+			}
+		}
+		return false;
+	}
+
+	private void debugDumpFailureState(int iter, String tag, QuickAccessDialog dialog, Table table) {
+		debugLog(iter, "=== FAILURE DUMP (" + tag + ") ===");
+		debugLog(iter, debugJobState(dialog));
+		debugLogProviders(iter, dialog);
+		if (table != null && !table.isDisposed()) {
+			List<String> entries = getAllEntries(table);
+			debugLog(iter, "table entries (" + entries.size() + "):");
+			for (int i = 0; i < entries.size(); i++) {
+				debugLog(iter, "  [" + i + "] " + entries.get(i));
+			}
+		} else {
+			debugLog(iter, "table null or disposed: " + table);
+		}
+		Shell[] shells = Display.getDefault().getShells();
+		debugLog(iter, "shells(" + shells.length + "):");
+		for (Shell s : shells) {
+			debugLog(iter, "  shell text=\"" + s.getText() + "\" disposed=" + s.isDisposed()
+					+ " visible=" + (!s.isDisposed() && s.isVisible()));
+		}
+		Job[] runningJobs = Job.getJobManager().find(null);
+		debugLog(iter, "running jobs(" + runningJobs.length + "):");
+		for (Job j : runningJobs) {
+			debugLog(iter, "  job name=\"" + j.getName() + "\" state=" + j.getState()
+					+ " result=" + j.getResult());
+		}
+		Map<Thread, StackTraceElement[]> stacks = Thread.getAllStackTraces();
+		debugLog(iter, "thread dump (" + stacks.size() + " threads):");
+		for (Map.Entry<Thread, StackTraceElement[]> e : stacks.entrySet()) {
+			Thread t = e.getKey();
+			StringBuilder sb = new StringBuilder();
+			sb.append("  \"").append(t.getName()).append("\" state=").append(t.getState());
+			for (StackTraceElement frame : e.getValue()) {
+				sb.append("\n    at ").append(frame);
+			}
+			debugLog(iter, sb.toString());
+		}
+		debugLog(iter, "=== END FAILURE DUMP (" + tag + ") ===");
 	}
 
 	@Test

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessDialogTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessDialogTest.java
@@ -298,7 +298,7 @@ public class QuickAccessDialogTest {
 
 	// DEBUG: instrumented @RepeatedTest to chase flakiness on CI.
 	// Revert to a normal @Test before merging the final fix.
-	@RepeatedTest(500)
+	@RepeatedTest(200)
 	public void testPreviousChoicesAvailableForExtension(RepetitionInfo info) {
 		int iter = info.getCurrentRepetition();
 		long testStart = System.currentTimeMillis();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessMatchingTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessMatchingTest.java
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Vogella GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.ui.tests.quickaccess;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.regex.Pattern;
+
+import org.eclipse.ui.internal.quickaccess.QuickAccessEntry;
+import org.eclipse.ui.internal.quickaccess.QuickAccessMatching;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pure unit tests for the matching helpers extracted from
+ * {@link org.eclipse.ui.internal.quickaccess.QuickAccessMatcher}. These run
+ * without a workbench harness, so they are fast and not flake-prone.
+ */
+public class QuickAccessMatchingTest {
+
+	@Test
+	public void substringQualityExactMatchIsPerfect() {
+		assertEquals(QuickAccessEntry.MATCH_PERFECT,
+				QuickAccessMatching.substringMatchQuality("Rename", "Rename", "rename"));
+	}
+
+	@Test
+	public void substringQualityPrefixIsExcellent() {
+		assertEquals(QuickAccessEntry.MATCH_EXCELLENT,
+				QuickAccessMatching.substringMatchQuality("Rename Resource", "Rename Resource", "rename"));
+	}
+
+	@Test
+	public void substringQualityMiddleIsGood() {
+		assertEquals(QuickAccessEntry.MATCH_GOOD,
+				QuickAccessMatching.substringMatchQuality("Find and Replace", "Find and Replace", "replace"));
+	}
+
+	@Test
+	public void substringQualityPartialWhenOnlyMatchLabelHits() {
+		// filter hits the match label but not the visible label -> partial
+		assertEquals(QuickAccessEntry.MATCH_PARTIAL,
+				QuickAccessMatching.substringMatchQuality("Rename Resource (keyword)", "Rename Resource", "keyword"));
+	}
+
+	@Test
+	public void substringQualityReturnsMinusOneOnMiss() {
+		assertEquals(-1, QuickAccessMatching.substringMatchQuality("Rename", "Rename", "xyzzy"));
+	}
+
+	@Test
+	public void whitespacesPatternSplitsOnWhitespace() {
+		Pattern p = QuickAccessMatching.whitespacesPattern("text white");
+		assertTrue(p.matcher("Text Editors: whitespace options").matches());
+		assertFalse(p.matcher("Unrelated entry").matches());
+	}
+
+	@Test
+	public void whitespacesPatternIsCaseInsensitive() {
+		Pattern p = QuickAccessMatching.whitespacesPattern("rename");
+		assertTrue(p.matcher("RENAME RESOURCE").matches());
+	}
+
+	@Test
+	public void wildcardsPatternHandlesStar() {
+		Pattern p = QuickAccessMatching.wildcardsPattern("re*ce");
+		assertTrue(p.matcher("Rename Resource").matches());
+		assertFalse(p.matcher("Delete").matches());
+	}
+
+	@Test
+	public void wildcardsPatternHandlesSingleQuestionMark() {
+		Pattern p = QuickAccessMatching.wildcardsPattern("te?t");
+		assertTrue(p.matcher("test").matches());
+		assertTrue(p.matcher("text").matches());
+	}
+
+	@Test
+	public void wildcardsPatternSquashesConsecutiveStars() {
+		Pattern a = QuickAccessMatching.wildcardsPattern("re***ce");
+		Pattern b = QuickAccessMatching.wildcardsPattern("re*ce");
+		// both should treat the input the same way
+		assertEquals(b.matcher("Rename Resource").matches(), a.matcher("Rename Resource").matches());
+		assertTrue(a.matcher("Rename Resource").matches());
+	}
+
+	@Test
+	public void safeCompileReturnsNonMatchingPatternForInvalidRegex() {
+		// "[" is an unterminated character class -> PatternSyntaxException
+		Pattern p = QuickAccessMatching.safeCompile("[");
+		assertNotNull(p);
+		assertFalse(p.matcher("any text").matches());
+		assertFalse(p.matcher("").matches());
+	}
+
+	@Test
+	public void safeCompileCompilesValidRegex() {
+		Pattern p = QuickAccessMatching.safeCompile("foo.*");
+		assertTrue(p.matcher("foobar").matches());
+	}
+}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessTestSuite.java
@@ -17,7 +17,7 @@ import org.junit.platform.suite.api.SelectClasses;
 import org.junit.platform.suite.api.Suite;
 
 @Suite
-@SelectClasses({ CamelUtilTest.class, QuickAccessDialogTest.class, ContentMatchesTest.class,
-		QuickAccessProvidersTest.class })
+@SelectClasses({ CamelUtilTest.class, QuickAccessMatchingTest.class, QuickAccessDialogTest.class,
+		ContentMatchesTest.class, QuickAccessProvidersTest.class })
 public class QuickAccessTestSuite {
 }


### PR DESCRIPTION
## Purpose

Draft PR to run a heavily instrumented version of
\`QuickAccessDialogTest.testPreviousChoicesAvailableForExtension\`
via GitHub Actions, in order to identify the root cause of its
flakiness observed on Windows CI (eclipse-platform/eclipse.platform.ui#80).

**Not for merge into vogella master either** - this is a runtime
diagnostic PR only. Close without merging once the root cause is
identified.

## Commits

1. \`Migrate QuickAccessDialogTest to JUnit 5\` - prerequisite so we can
   use \`@RepeatedTest\`. This commit IS intended for upstream later.
2. \`DEBUG: instrument testPreviousChoicesAvailableForExtension\` -
   diagnostic-only. \`@RepeatedTest(500)\` + detailed per-poll logging +
   failure dump with thread stacks, all jobs, all shells, compute-job
   state, and full table entry list.

## What we are looking for

- Whether the compute \`Job\` finishes within the 5s TIMEOUT.
- Whether the \`TestQuickAccessComputer\` provider appears in the
  registered provider list on the failing iteration.
- Whether an \`asyncExec\` callback is blocked / delayed on the UI thread.
- Whether the failure is concentrated on the cold first iteration (ie.
  first extension-point query in the test class) or distributed.

## Test plan

- [ ] CI runs the 500 iterations on all three OS targets.
- [ ] Collect failing-iteration logs from the Actions artifact for
      analysis.