### PR TITLE
Suppress intermediate repaints in StackRenderer.showTab()

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/StackRenderer.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/StackRenderer.java
@@ -1484,28 +1484,34 @@ public class StackRenderer extends LazyStackRenderer {
 			createTab(element.getParent(), element);
 			tabItem = findItemForPart(element, element.getParent());
 		}
-		Control ctrl = (Control) element.getWidget();
-		if (ctrl != null && ctrl.getParent() != tabFolder) {
-			ctrl.setParent(tabFolder);
-			tabItem.setControl(ctrl);
-		} else if (element.getWidget() == null) {
-			Control tabCtrl = (Control) renderer.createGui(element);
-			tabItem.setControl(tabCtrl);
-		}
 
-		ignoreTabSelChanges = true;
-		// Ensure that the newly selected control is correctly sized
-		if (tabItem.getControl() instanceof Composite) {
-			Composite ctiComp = (Composite) tabItem.getControl();
-			// see bug 461573, 528720: call below is still needed to make view
-			// descriptions visible after unhiding the view with changed bounds
-			ctiComp.requestLayout();
-		}
-		tabFolder.setSelection(tabItem);
-		ignoreTabSelChanges = false;
+		// Suppress intermediate repaints while mutating the widget tree
+		tabFolder.setRedraw(false);
+		try {
+			Control ctrl = (Control) element.getWidget();
+			if (ctrl != null && ctrl.getParent() != tabFolder) {
+				ctrl.setParent(tabFolder);
+				tabItem.setControl(ctrl);
+			} else if (element.getWidget() == null) {
+				Control tabCtrl = (Control) renderer.createGui(element);
+				tabItem.setControl(tabCtrl);
+			}
 
-		// Show the new state
-		adjustTopRight(tabFolder);
+			ignoreTabSelChanges = true;
+			// Ensure that the newly selected control is correctly sized
+			if (tabItem.getControl() instanceof Composite ctiComp) {
+				// see bug 461573, 528720: call below is still needed to make view
+				// descriptions visible after unhiding the view with changed bounds
+				ctiComp.requestLayout();
+			}
+			tabFolder.setSelection(tabItem);
+			ignoreTabSelChanges = false;
+
+			// Show the new state
+			adjustTopRight(tabFolder);
+		} finally {
+			tabFolder.setRedraw(true);
+		}
 	}
 
 	protected void showMenu(ToolItem item) {


### PR DESCRIPTION
## Summary

Wraps the widget-mutation section of `StackRenderer.showTab()` in `setRedraw(false)` / `setRedraw(true)` on the `CTabFolder` to suppress intermediate repaints during `setParent`, `setControl`, `requestLayout`, `setSelection`, and `adjustTopRight`.

The `lazyLoader` event handler already did this at the call site; the fix moves the batching into `showTab` itself so all callers (including `postProcess`) benefit.

## Motivation

Tracing on `wip-adding-performance-trace-code` (H10) shows `showTab` is the dominant renderer hotspot:

- Session 1 (baseline): 1,566 ms total, worst call 977 ms, 9 calls
- Session 2: 1,817 ms total, worst call 1,209 ms, 8 calls
- Session 3 (latest): 1,284 ms total, worst call 986 ms, 27 calls

H10 alone accounts for roughly 60 to 72 percent of all measured renderer overhead across sessions. Five of nine calls in Session 1 exceeded the 16 ms frame budget; the worst-case tail is close to a full second of frozen UI.

## Test plan

- [ ] Re-run the tracer on this branch and confirm H10 total drops by the expected 80 to 95 percent
- [ ] Smoke test editor/view switching and perspective changes
- [ ] Smoke test startup (workbench window restoration)
- [ ] Confirm no visual regressions during tab switches (no partial-paint artifacts)