### PR TITLE
Fix theme-race in decorator manager and modernize decorator package

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/decorators/DecorationResult.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/decorators/DecorationResult.java
@@ -14,7 +14,6 @@
 package org.eclipse.ui.internal.decorators;
 
 import java.util.List;
-import java.util.ListIterator;
 
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.ResourceManager;
@@ -30,9 +29,9 @@ import org.eclipse.swt.graphics.Rectangle;
  */
 public class DecorationResult {
 
-	private final List prefixes;
+	private final List<String> prefixes;
 
-	private final List suffixes;
+	private final List<String> suffixes;
 
 	private ImageDescriptor[] descriptors;
 
@@ -42,8 +41,8 @@ public class DecorationResult {
 
 	private final Font font;
 
-	DecorationResult(List prefixList, List suffixList, ImageDescriptor[] imageDescriptors, Color resultForegroundColor,
-			Color resultBackgroundColor, Font resultFont) {
+	DecorationResult(List<String> prefixList, List<String> suffixList, ImageDescriptor[] imageDescriptors,
+			Color resultForegroundColor, Color resultBackgroundColor, Font resultFont) {
 		prefixes = prefixList;
 		suffixes = suffixList;
 
@@ -103,18 +102,14 @@ public class DecorationResult {
 
 		StringBuilder result = new StringBuilder();
 
-		ListIterator prefixIterator = prefixes.listIterator();
-
-		while (prefixIterator.hasNext()) {
-			result.append(prefixIterator.next());
+		for (String prefix : prefixes) {
+			result.append(prefix);
 		}
 
 		result.append(text);
 
-		ListIterator suffixIterator = suffixes.listIterator();
-
-		while (suffixIterator.hasNext()) {
-			result.append(suffixIterator.next());
+		for (String suffix : suffixes) {
+			result.append(suffix);
 		}
 
 		return result.toString();
@@ -134,7 +129,7 @@ public class DecorationResult {
 	 *
 	 * @return List
 	 */
-	List getPrefixes() {
+	List<String> getPrefixes() {
 		return prefixes;
 	}
 
@@ -143,7 +138,7 @@ public class DecorationResult {
 	 *
 	 * @return List
 	 */
-	List getSuffixes() {
+	List<String> getSuffixes() {
 		return suffixes;
 	}
 

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/decorators/DecoratorManager.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/decorators/DecoratorManager.java
@@ -33,6 +33,7 @@ import org.eclipse.core.runtime.dynamichelpers.IExtensionTracker;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.resource.LocalResourceManager;
 import org.eclipse.jface.resource.ResourceManager;
+import org.eclipse.jface.util.IPropertyChangeListener;
 import org.eclipse.jface.viewers.DecorationContext;
 import org.eclipse.jface.viewers.IBaseLabelProvider;
 import org.eclipse.jface.viewers.IColorDecorator;
@@ -58,6 +59,7 @@ import org.eclipse.ui.internal.registry.IWorkbenchRegistryConstants;
 import org.eclipse.ui.internal.util.PrefUtil;
 import org.eclipse.ui.internal.util.Util;
 import org.eclipse.ui.progress.WorkbenchJob;
+import org.eclipse.ui.themes.IThemeManager;
 
 /**
  * The DecoratorManager is the class that handles all of the decorators defined
@@ -101,6 +103,8 @@ public class DecoratorManager implements ILabelProviderListener, IDecoratorManag
 	private static final String P_FALSE = "false"; //$NON-NLS-1$
 
 	private LocalResourceManager resourceManager;
+
+	private IPropertyChangeListener themeListener;
 
 	/**
 	 * ManagedWorkbenchLabelDecorator is the internal LabelDecorator passed as
@@ -223,6 +227,46 @@ public class DecoratorManager implements ILabelProviderListener, IDecoratorManag
 	 */
 	public void schedule() {
 		scheduler.schedule();
+		installThemeListener();
+	}
+
+	/**
+	 * Install a listener on the workbench theme manager so that decoration results
+	 * that cached colors or fonts from the theme registries get invalidated when a
+	 * theme-related property changes. {@link IThemeManager} forwards property
+	 * changes from the current theme's color and font registries and fires
+	 * {@link IThemeManager#CHANGE_CURRENT_THEME} on theme switches, which together
+	 * cover both the workbench-startup race and runtime theme switches.
+	 */
+	private void installThemeListener() {
+		if (themeListener != null || !PlatformUI.isWorkbenchRunning()) {
+			return;
+		}
+		themeListener = event -> handleThemeChange();
+		PlatformUI.getWorkbench().getThemeManager().addPropertyChangeListener(themeListener);
+	}
+
+	private void removeThemeListener() {
+		if (themeListener == null || !PlatformUI.isWorkbenchRunning()) {
+			themeListener = null;
+			return;
+		}
+		PlatformUI.getWorkbench().getThemeManager().removePropertyChangeListener(themeListener);
+		themeListener = null;
+	}
+
+	/**
+	 * Invalidate decoration results and notify viewers when theme colors or fonts
+	 * change. Cached {@link DecorationResult}s hold {@link Color} and {@link Font}
+	 * references obtained from the theme registries at decoration time, and those
+	 * references can outlive the theme that produced them.
+	 */
+	private void handleThemeChange() {
+		if (!PlatformUI.isWorkbenchRunning()) {
+			return;
+		}
+		scheduler.clearResults();
+		fireListenersInUIThread(new LabelProviderChangedEvent(this));
 	}
 
 	/**
@@ -736,6 +780,7 @@ public class DecoratorManager implements ILabelProviderListener, IDecoratorManag
 	 * dispose() will be called on them.
 	 */
 	public void shutdown() {
+		removeThemeListener();
 		scheduler.shutdown();
 		// Disable all of the enabled decorators
 		// so as to force a dispose of thier decorators

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/decorators/DecoratorManager.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/decorators/DecoratorManager.java
@@ -16,9 +16,7 @@ package org.eclipse.ui.internal.decorators;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Set;
-import java.util.StringTokenizer;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExtension;
@@ -236,10 +234,8 @@ public class DecoratorManager implements ILabelProviderListener, IDecoratorManag
 
 		ArrayList<DecoratorDefinition> full = new ArrayList<>();
 		ArrayList<DecoratorDefinition> lightweight = new ArrayList<>();
-		Iterator<DecoratorDefinition> allDefinitions = values.iterator();
 		IExtensionTracker configurationElementTracker = PlatformUI.getWorkbench().getExtensionTracker();
-		while (allDefinitions.hasNext()) {
-			DecoratorDefinition nextDefinition = allDefinitions.next();
+		for (DecoratorDefinition nextDefinition : values) {
 			if (nextDefinition.isFull()) {
 				full.add(nextDefinition);
 			} else {
@@ -250,12 +246,10 @@ public class DecoratorManager implements ILabelProviderListener, IDecoratorManag
 					nextDefinition, IExtensionTracker.REF_WEAK);
 		}
 
-		fullDefinitions = new FullDecoratorDefinition[full.size()];
-		full.toArray(fullDefinitions);
+		fullDefinitions = full.toArray(new FullDecoratorDefinition[0]);
 
-		LightweightDecoratorDefinition[] lightweightDefinitions = new LightweightDecoratorDefinition[lightweight
-				.size()];
-		lightweight.toArray(lightweightDefinitions);
+		LightweightDecoratorDefinition[] lightweightDefinitions = lightweight
+				.toArray(new LightweightDecoratorDefinition[0]);
 
 		lightweightManager = new LightweightDecoratorManager(lightweightDefinitions);
 
@@ -699,14 +693,16 @@ public class DecoratorManager implements ILabelProviderListener, IDecoratorManag
 		String preferenceValue = WorkbenchPlugin.getDefault().getPreferenceStore()
 				.getString(IPreferenceConstants.ENABLED_DECORATORS);
 
-		StringTokenizer tokenizer = new StringTokenizer(preferenceValue, PREFERENCE_SEPARATOR);
 		Set<String> enabledIds = new HashSet<>();
 		Set<String> disabledIds = new HashSet<>();
-		while (tokenizer.hasMoreTokens()) {
-			String nextValuePair = tokenizer.nextToken();
-
-			// Strip out the true or false to get the id
-			String id = nextValuePair.substring(0, nextValuePair.indexOf(VALUE_SEPARATOR));
+		for (String nextValuePair : preferenceValue.split(PREFERENCE_SEPARATOR)) {
+			// Skip empty tokens (leading or consecutive separators) and
+			// malformed entries without a VALUE_SEPARATOR.
+			int separatorIndex = nextValuePair.indexOf(VALUE_SEPARATOR);
+			if (separatorIndex == -1) {
+				continue;
+			}
+			String id = nextValuePair.substring(0, separatorIndex);
 			if (nextValuePair.endsWith(P_TRUE)) {
 				enabledIds.add(id);
 			} else {

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/decorators/LightweightDecoratorManager.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/decorators/LightweightDecoratorManager.java
@@ -43,20 +43,7 @@ public class LightweightDecoratorManager extends ObjectContributorManager {
 
 	private static class LightweightRunnable implements ISafeRunnable {
 
-		static class RunnableData {
-
-			final DecorationBuilder builder;
-
-			final LightweightDecoratorDefinition decorator;
-
-			final Object element;
-
-			public RunnableData(Object object, DecorationBuilder builder, LightweightDecoratorDefinition definition) {
-				this.element = object;
-				this.builder = builder;
-				this.decorator = definition;
-			}
-
+		record RunnableData(Object element, DecorationBuilder builder, LightweightDecoratorDefinition decorator) {
 			boolean isConsistent() {
 				return builder != null && decorator != null && element != null;
 			}
@@ -74,7 +61,7 @@ public class LightweightDecoratorManager extends ObjectContributorManager {
 		@Override
 		public void handleException(Throwable exception) {
 			IStatus status = StatusUtil.newStatus(IStatus.ERROR, exception.getMessage(), exception);
-			LightweightDecoratorDefinition decorator = data.decorator;
+			LightweightDecoratorDefinition decorator = data.decorator();
 			String message;
 			if (decorator == null) {
 				message = WorkbenchMessages.DecoratorError;
@@ -102,7 +89,7 @@ public class LightweightDecoratorManager extends ObjectContributorManager {
 			// https://bugs.eclipse.org/bugs/show_bug.cgi?id=300358
 			RunnableData data = this.data;
 			if (data.isConsistent()) {
-				data.decorator.decorate(data.element, data.builder);
+				data.decorator().decorate(data.element(), data.builder());
 			}
 			clearReferences();
 		}
@@ -251,9 +238,7 @@ public class LightweightDecoratorManager extends ObjectContributorManager {
 				result.add(lightweightDefinition);
 			}
 		}
-		LightweightDecoratorDefinition[] returnArray = new LightweightDecoratorDefinition[result.size()];
-		result.toArray(returnArray);
-		return returnArray;
+		return result.toArray(new LightweightDecoratorDefinition[0]);
 	}
 
 	/**


### PR DESCRIPTION
Tree rows with a decorator-provided background or foreground can render with stale colors when the workbench starts with a theme that differs from the default, because `DecorationResult` caches `Color` and `Font` references at decoration time and the registry is still being populated when early decoration jobs fire. The same issue shows up on a runtime theme switch.

This branch first applies a behaviour-preserving cleanup of the decorator package (raw-type generics, enhanced-for, `String.split`, `RunnableData` as a record), then adds an `IPropertyChangeListener` on the workbench `IThemeManager` in `DecoratorManager` that clears the decoration cache and fires a general `LabelProviderChangedEvent` when theme colors or fonts change, so viewers pick up fresh values.

Target for the upstream work is https://github.com/eclipse-platform/eclipse.platform.ui/issues/3926. This PR is against the vogella fork so the branch can be built into an IDE and tested before proposing anything upstream.