### PR TITLE
Use ILog.of in IDEApplication version-file logger

### DIFF
--- a/bundles/org.eclipse.ui.ide.application/src/org/eclipse/ui/internal/ide/application/IDEApplication.java
+++ b/bundles/org.eclipse.ui.ide.application/src/org/eclipse/ui/internal/ide/application/IDEApplication.java
@@ -36,6 +36,7 @@ import java.util.Properties;
 
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExecutableExtension;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IProduct;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.OperationCanceledException;
@@ -74,7 +75,6 @@ import org.eclipse.ui.internal.ide.ChooseWorkspaceDialog;
 import org.eclipse.ui.internal.ide.IDEInternalPreferences;
 import org.eclipse.ui.internal.ide.IDEWorkbenchMessages;
 import org.eclipse.ui.internal.ide.IDEWorkbenchPlugin;
-import org.eclipse.ui.internal.ide.StatusUtil;
 import org.eclipse.ui.preferences.ScopedPreferenceStore;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.Version;
@@ -838,8 +838,7 @@ public class IDEApplication implements IApplication, IExecutableExtension {
 		try (OutputStream output = new FileOutputStream(versionFile)) {
 			props.store(output, null);
 		} catch (IOException e) {
-			IDEWorkbenchPlugin.log("Could not write version file", //$NON-NLS-1$
-					StatusUtil.newError(e));
+			ILog.of(IDEApplication.class).error("Could not write version file", e); //$NON-NLS-1$
 		}
 	}
 

--- a/bundles/org.eclipse.ui.ide.application/src/org/eclipse/ui/internal/ide/application/IDEApplication.java
+++ b/bundles/org.eclipse.ui.ide.application/src/org/eclipse/ui/internal/ide/application/IDEApplication.java
@@ -165,11 +165,13 @@ public class IDEApplication implements IApplication, IExecutableExtension {
 			// look and see if there's a splash shell we can parent off of
 			Shell shell = WorkbenchPlugin.getSplashShell(display);
 			if (shell != null) {
-				// should should set the icon and message for this shell to be the
-				// same as the chooser dialog - this will be the guy that lives in
-				// the task bar and without these calls you'd have the default icon
-				// with no message.
-				shell.setText(ChooseWorkspaceDialog.getWindowTitle());
+				// Set the taskbar title and icon for the splash shell. The title
+				// is taken from the configured product; if no product is set, the
+				// launcher's default title is kept.
+				IProduct product = Platform.getProduct();
+				if (product != null && product.getName() != null) {
+					shell.setText(product.getName());
+				}
 				shell.setImages(Window.getDefaultImages());
 			}
 

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/FilteredPreferenceDialog.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/FilteredPreferenceDialog.java
@@ -119,6 +119,18 @@ public abstract class FilteredPreferenceDialog extends PreferenceDialog implemen
 			super(parent, treeStyle, filter, true, true);
 		}
 
+		@Override
+		protected Text doCreateFilterText(Composite parent) {
+			return new Text(parent, SWT.SINGLE | SWT.BORDER | SWT.SEARCH | SWT.ICON_SEARCH | SWT.ICON_CANCEL);
+		}
+
+		@Override
+		public void setInitialText(String text) {
+			if (filterText != null && !filterText.isDisposed()) {
+				filterText.setMessage(text != null ? text : ""); //$NON-NLS-1$
+			}
+		}
+
 		/**
 		 * Add an additional, optional filter to the viewer. If the filter text is
 		 * cleared, this filter will be removed from the TreeViewer.


### PR DESCRIPTION
Migrates the single cross-bundle `StatusUtil.newError(e)` in `IDEApplication#writeVersion` to `ILog.of(IDEApplication.class).error(message, throwable)`. The logged plug-in id moves from `"org.eclipse.ui.ide"` to `"org.eclipse.ui.ide.application"` — the bundle that actually emits the version-file write failure — and the previous double-log emitted by `IDEWorkbenchPlugin.log(message, status)` collapses to a single coherent entry. As a side effect the dependency on `IOException.getLocalizedMessage()` (potentially null) goes away.

Tracked in vogellacompany/tasks#1837. The larger `org.eclipse.ui.workbench` migration is still blocked on the open plug-in-id decision and is not in this PR.